### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/health-dashboard.yml
+++ b/.github/workflows/health-dashboard.yml
@@ -25,10 +25,10 @@ jobs:
           git pull
           git add --all
           if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
           else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
       - name: Push changes

--- a/.github/workflows/issue-view.yml
+++ b/.github/workflows/issue-view.yml
@@ -25,10 +25,10 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --all
           if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
           else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/issues-ace-team.yml
+++ b/.github/workflows/issues-ace-team.yml
@@ -25,10 +25,10 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --all
           if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
           else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/pr-view.yml
+++ b/.github/workflows/pr-view.yml
@@ -26,10 +26,10 @@ jobs:
         git config --local user.name "GitHub Action"
         git add --all
         if [-z "$(git status --porcelain)"]; then
-           echo "::set-output name=push::false"
+           echo "push=false" >> $GITHUB_OUTPUT
         else
            git commit -m "Add changes" -a
-           echo "::set-output name=push::true"
+           echo "push=true" >> $GITHUB_OUTPUT
         fi
       shell: bash
  

--- a/.github/workflows/transitioned-issues.yml
+++ b/.github/workflows/transitioned-issues.yml
@@ -25,10 +25,10 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --all
           if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
           else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
           fi
         shell: bash
 

--- a/.github/workflows/validation-repo-test.yml
+++ b/.github/workflows/validation-repo-test.yml
@@ -32,10 +32,10 @@ jobs:
            git pull
            git add --all
            if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
            else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
            fi
       shell: bash
     - name: Push changes
@@ -60,10 +60,10 @@ jobs:
            git pull
            git add --all
            if [-z "$(git status --porcelain)"]; then
-             echo "::set-output name=push::false"
+             echo "push=false" >> $GITHUB_OUTPUT
            else
              git commit -m "Add changes" -a
-             echo "::set-output name=push::true"
+             echo "push=true" >> $GITHUB_OUTPUT
            fi
       shell: bash
     - name: Push changes


### PR DESCRIPTION
## Description

Resolve  #149  

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=push::false"
```

```yml
echo "::set-output name=push::true"
```

**TO-BE**

```yml
echo "push=false" >> $GITHUB_OUTPUT
```

```yml
echo "push=true" >> $GITHUB_OUTPUT
```